### PR TITLE
Update serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ build = "build.rs"
 
 [build-dependencies.serde_codegen]
 optional = true
-version = "0.7.10"
+version = "0.8.19"
 
 [dependencies]
 log = "0.3.6"
-serde = "0.7.10"
-serde_xml = "0.7.0"
+serde = "0.8.19"
+serde_xml = "0.9.1"
 
 [dependencies.clippy]
 optional = true
@@ -42,9 +42,9 @@ version = "0.0"
 optional = true
 version = "0.9.5"
 
-[dependencies.serde_macros]
+[dependencies.serde_derive]
 optional = true
-version = "0.7.10"
+version = "0.8.19"
 
 [dependencies.url]
 features = ["serde"]
@@ -52,6 +52,6 @@ version = "1.1.1"
 
 [features]
 default = ["hyper", "with-syntex"]
-nightly = ["serde_macros"]
+nightly = ["serde_derive"]
 nightly-testing = ["clippy", "nightly"]
 with-syntex = ["serde_codegen"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 #![deny(missing_docs)]
 #![deny(non_camel_case_types)]
 #![deny(warnings)]
+#![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![cfg_attr(feature = "nightly", feature(custom_derive, plugin))]
-#![cfg_attr(feature = "nightly", plugin(serde_macros))]
+#![cfg_attr(feature = "nightly", feature(custom_derive, proc_macro))]
 
 //! A library providing Rust bindings for the Wolfram|Alpha web API.
 //!
@@ -34,6 +34,9 @@ extern crate hyper;
 #[macro_use]
 extern crate log;
 extern crate serde;
+#[cfg(feature = "nightly")]
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_xml;
 extern crate url;
 


### PR DESCRIPTION
Update serde to latest version, as well as to use the latest libraries (i.e.
`serde_derive`, which relies on the `proc_macro` feature).