### PR TITLE
Fix OS X CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,13 @@ before_script:
       else
         export PATH=$HOME/Library/Python/2.7/bin:$PATH
       fi
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "osx"  ]]; then
+        brew install openssl && \
+        export OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include && \
+        export OPENSSL_LIB_DIR=`brew --prefix openssl`/lib && \
+        echo "Installed OpenSSL for OS X."
+      fi
 # the main build
 script:
   - |
@@ -47,11 +54,16 @@ script:
       else
         travis-cargo bench
       fi &&
-      travis-cargo --only stable doc
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        travis-cargo --only stable doc
+      fi
 after_success:
   # upload the documentation from the build with stable (automatically only
-  # actually runs from the master branch, not individual PRs)
-  - travis-cargo --only stable doc-upload
+  # actually runs from the master branch, not individual PRs), not on OS X.
+  - |
+      if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        travis-cargo --only stable doc-upload
+      fi
   # measure code coverage and upload to coveralls.io (the verify argument
   # mitigates kcov crashes due to malformed debuginfo, at the cost of some
   # speed. <https://github.com/huonw/travis-cargo/issues/12>)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.8.19"
 [dependencies]
 log = "0.3.6"
 serde = "0.8.19"
-serde_xml = "0.9.1"
+serde_xml = "0.8.1"
 
 [dependencies.clippy]
 optional = true

--- a/src/model.rs
+++ b/src/model.rs
@@ -27,7 +27,7 @@ include!(concat!(env!("OUT_DIR"), "/model.rs"));
 mod tests {
     use serde_xml::from_str;
 
-    use super::{Img, Infos, Pod, QueryResult, Subpod};
+    use super::{Img, Infos, Plaintext, Pod, QueryResult, Subpod};
 
     #[test]
     fn test_query_result_deserializer() {
@@ -89,6 +89,12 @@ mod tests {
     fn test_img_deserializer() {
         let s = IMG_STR.to_owned();
         from_str::<Img>(&s).unwrap();
+    }
+
+    #[test]
+    fn test_plaintext_deserializer() {
+        from_str::<Plaintext>(&"<plaintext>pi</plaintext>".to_owned()).unwrap();
+        from_str::<Option<Plaintext>>(&"<plaintext/>".to_owned()).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Modify Travis CI config to install OpenSSL on OS X. Intended to fix Travis CI
builds.

Closes #7.