### PR TITLE
Cut the 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="v0.2.0"></a>
+## v0.2.0 (2016-12-15)
+
+
+#### Features
+
+*   fix/add various structs ([f93151be](https://github.com/indiv0/wolfram-alpha-rs/commit/f93151bebf62d716436cddb5e0ae3c32c8099288))
+*   add `Statelist` struct ([abfdcb8b](https://github.com/indiv0/wolfram-alpha-rs/commit/abfdcb8b9bf1713295f4fcdde5eddf3ad5eeff36))
+
+#### Improvements
+
+*   enable primary field for Pod struct ([47c7d0ee](https://github.com/indiv0/wolfram-alpha-rs/commit/47c7d0ee08c4f90b0f5f9e20b8bbb97552db7855))
+
+
+
 <a name="v0.1.1"></a>
 ## v0.1.1 (2016-12-01)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wolfram_alpha"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Nikita Pekin <contact@nikitapek.in>"]
 description = "A library providing Rust bindings for the Wolfram|Alpha API"
 repository = "https://github.com/indiv0/wolfram-alpha-rs"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-wolfram_alpha = "0.1"
+wolfram_alpha = "0.2"
 ```
 
 And in your `lib.rs` or `main.rs`:


### PR DESCRIPTION
Cut the 0.1.1 release.
Update `CHANGELOG.md`, `Cargo.toml`, and `README.md` with new version.