### PR TITLE
Add `Notes` struct and `Note` type

### DIFF
--- a/src/model.in.rs
+++ b/src/model.in.rs
@@ -251,6 +251,7 @@ pub struct Pod {
     //pub error: Option<Error>,
     pub sounds: Option<Sounds>,
     pub definitions: Option<Definitions>,
+    pub notes: Option<Notes>,
 }
 
 /// A series of `State` attributes.
@@ -335,6 +336,18 @@ pub struct Definition {
     pub word: String,
     pub desc: String,
 }
+
+/// A series of `Note` attributes.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct Notes {
+    // Attributes
+    pub count: u32,
+
+    pub note: Vec<Note>,
+}
+
+/// A note made by Wolfram|Alpha regarding a query.
+pub type Note = String;
 
 /// A subelement of `Pod`.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -38,6 +38,7 @@ mod tests {
         Img,
         Infos,
         LanguageMsg,
+        Notes,
         Plaintext,
         Pod,
         QueryResult,
@@ -67,6 +68,11 @@ mod tests {
         from_str::<QueryResult>(&read_sample_data_from_path("tests/sample-data/query_result_4.xml")).unwrap();
         from_str::<QueryResult>(&read_sample_data_from_path("tests/sample-data/query_result_5.xml")).unwrap();
         from_str::<QueryResult>(&read_sample_data_from_path("tests/sample-data/query_result_6.xml")).unwrap();
+    }
+
+    #[test]
+    fn test_notes_deserializer() {
+        from_str::<Notes>(&read_sample_data_from_path("tests/sample-data/notes.xml")).unwrap();
     }
 
     #[test]

--- a/tests/sample-data/notes.xml
+++ b/tests/sample-data/notes.xml
@@ -1,0 +1,3 @@
+<notes count='1'>
+ <note>QR Code is a registered trademark of Denso Wave Inc.</note>
+</notes>


### PR DESCRIPTION
Add `Notes` struct and `None` type to represent the possible notes that W|A
might return regarding a query.
Add test for `Notes` struct deserialization.